### PR TITLE
BUGFIX: Accept shortcuts in toLocaleString methods

### DIFF
--- a/packages/temporal-polyfill/src/public/instant.ts
+++ b/packages/temporal-polyfill/src/public/instant.ts
@@ -179,9 +179,11 @@ mixinLocaleStringMethods(Instant, createZonedFormatFactoryFactory({
   month: 'numeric',
   day: 'numeric',
   weekday: undefined,
+  dateStyle: undefined,
   hour: 'numeric',
   minute: '2-digit',
   second: '2-digit',
+  timeStyle: undefined,
 }, {
   timeZoneName: undefined,
 }, {}))

--- a/packages/temporal-polyfill/src/public/plainDate.ts
+++ b/packages/temporal-polyfill/src/public/plainDate.ts
@@ -184,6 +184,7 @@ mixinLocaleStringMethods(PlainDate, createPlainFormatFactoryFactory({
   month: 'numeric',
   day: 'numeric',
   weekday: undefined,
+  dateStyle: undefined,
 }, {
   hour: undefined,
   minute: undefined,

--- a/packages/temporal-polyfill/src/public/plainDateTime.ts
+++ b/packages/temporal-polyfill/src/public/plainDateTime.ts
@@ -231,9 +231,11 @@ mixinLocaleStringMethods(PlainDateTime, createPlainFormatFactoryFactory({
   month: 'numeric',
   day: 'numeric',
   weekday: undefined,
+  dateStyle: undefined,
   hour: 'numeric',
   minute: '2-digit',
   second: '2-digit',
+  timeStyle: undefined,
 }, {}))
 
 // creation

--- a/packages/temporal-polyfill/src/public/plainTime.ts
+++ b/packages/temporal-polyfill/src/public/plainTime.ts
@@ -166,18 +166,25 @@ function createPlainTimeFormatFactory(
 ): FormatFactory<PlainTime> {
   return {
     buildKey: () => ['', ''],
-    buildFormat: () => new OrigDateTimeFormat(locales, {
-      hour: 'numeric',
-      minute: '2-digit',
-      second: '2-digit',
-      ...options,
-      timeZone: 'UTC', // options can't override
-      timeZoneName: undefined,
-      year: undefined,
-      month: undefined,
-      day: undefined,
-      weekday: undefined,
-    }),
+    buildFormat: () => {
+      const defaultOptions: Intl.DateTimeFormatOptions | undefined = options?.timeStyle == null
+        ? {
+            hour: 'numeric',
+            minute: '2-digit',
+            second: '2-digit',
+          }
+        : undefined
+      return new OrigDateTimeFormat(locales, {
+        ...defaultOptions,
+        ...options,
+        timeZone: 'UTC', // options can't override
+        timeZoneName: undefined,
+        year: undefined,
+        month: undefined,
+        day: undefined,
+        weekday: undefined,
+      })
+    },
     buildEpochMilli: (plainTime: PlainTime) => (
       Math.trunc(isoTimeToNano(plainTime.getISOFields()) / nanoInMilli)
     ),

--- a/packages/temporal-polyfill/src/public/zonedDateTime.ts
+++ b/packages/temporal-polyfill/src/public/zonedDateTime.ts
@@ -299,9 +299,11 @@ mixinLocaleStringMethods(ZonedDateTime, createZonedFormatFactoryFactory({
   month: 'numeric',
   day: 'numeric',
   weekday: undefined,
+  dateStyle: undefined,
   hour: 'numeric',
   minute: '2-digit',
   second: '2-digit',
+  timeStyle: undefined,
 }, {
   timeZoneName: 'short',
 }, {}))

--- a/packages/temporal-polyfill/tests/intl.js
+++ b/packages/temporal-polyfill/tests/intl.js
@@ -124,6 +124,12 @@ describe('Intl', () => {
       });
       throws(() => dt.toLocaleString('en-US-u-ca-japanese'));
     });
+    it(`(${datetime.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium', timeStyle: 'short' })`, () =>
+      equal(`${datetime.toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium', timeStyle: 'short' })}`, '18 nov. 1976, 15:23'));
+    it(`(${datetime.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium' })`, () =>
+      equal(`${datetime.toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium' })}`, '18 nov. 1976'));
+    it(`(${datetime.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', timeStyle: 'short' })`, () =>
+      equal(`${datetime.toLocaleString('fr', { timeZone: 'Europe/Paris', timeStyle: 'short' })}`, '15:23'));
   });
   describe('time.toLocaleString()', () => {
     const time = Temporal.PlainTime.from('1976-11-18T15:23:30');

--- a/packages/temporal-polyfill/tests/intl.js
+++ b/packages/temporal-polyfill/tests/intl.js
@@ -126,6 +126,8 @@ describe('Intl', () => {
       equal(time.toLocaleString('en', { day: 'numeric' }), '3:23:30 PM');
       equal(time.toLocaleString('en', { weekday: 'long' }), '3:23:30 PM');
     });
+    it(`(${time.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', timeStyle: 'short' })`, () =>
+      equal(`${time.toLocaleString('fr', { timeZone: 'Europe/Paris', timeStyle: 'short' })}`, '15:23'));
   });
   describe('date.toLocaleString()', () => {
     const date = Temporal.PlainDate.from('1976-11-18T15:23:30');

--- a/packages/temporal-polyfill/tests/intl.js
+++ b/packages/temporal-polyfill/tests/intl.js
@@ -157,6 +157,8 @@ describe('Intl', () => {
       const d = Temporal.PlainDate.from({ year: 1976, month: 11, day: 18, calendar: 'gregory' });
       throws(() => d.toLocaleString('en-US-u-ca-japanese'));
     });
+    it(`(${date.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium' })`, () =>
+      equal(`${date.toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium' })}`, '18 nov. 1976'));
   });
   describe('yearmonth.toLocaleString()', () => {
     const calendar = new Intl.DateTimeFormat('en').resolvedOptions().calendar;

--- a/packages/temporal-polyfill/tests/intl.js
+++ b/packages/temporal-polyfill/tests/intl.js
@@ -71,6 +71,12 @@ describe('Intl', () => {
       const zdt = new Temporal.ZonedDateTime(0n, 'UTC', 'gregory');
       throws(() => zdt.toLocaleString('en-US-u-ca-japanese'));
     });
+    it(`(${zdt}).toLocaleString('fr', { dateStyle: 'medium', timeStyle: 'short' })`, () =>
+      equal(zdt.toLocaleString('fr', { dateStyle: 'medium', timeStyle: 'short' }), '18 nov. 1976, 15:23'));
+    it(`(${zdt}).toLocaleString('fr', { dateStyle: 'medium' })`, () =>
+      equal(zdt.toLocaleString('fr', { dateStyle: 'medium' }), '18 nov. 1976'));
+    it(`(${zdt}).toLocaleString('fr', { timeStyle: 'short' })`, () =>
+      equal(zdt.toLocaleString('fr', { timeStyle: 'short' }), '15:23'));
   });
   describe('datetime.toLocaleString()', () => {
     const datetime = Temporal.PlainDateTime.from('1976-11-18T15:23:30');

--- a/packages/temporal-polyfill/tests/intl.js
+++ b/packages/temporal-polyfill/tests/intl.js
@@ -32,6 +32,12 @@ describe('Intl', () => {
       const str = instant.toLocaleString('en', { timeZone: 'America/New_York', timeZoneName: 'short' });
       assert(str.includes('EST'));
     });
+    it(`(${instant.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium', timeStyle: 'short' })`, () =>
+      equal(`${instant.toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium', timeStyle: 'short' })}`, '18 nov. 1976, 15:23'));
+    it(`(${instant.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium' })`, () =>
+      equal(`${instant.toLocaleString('fr', { timeZone: 'Europe/Paris', dateStyle: 'medium' })}`, '18 nov. 1976'));
+    it(`(${instant.toString()}).toLocaleString('fr', { timeZone: 'Europe/Paris', timeStyle: 'short' })`, () =>
+      equal(`${instant.toLocaleString('fr', { timeZone: 'Europe/Paris', timeStyle: 'short' })}`, '15:23'));
   });
   describe('zoneddatetime.toLocaleString()', () => {
     const zdt = Temporal.ZonedDateTime.from('1976-11-18T15:23:30+01:00[Europe/Vienna]');


### PR DESCRIPTION
This is a bug fix for #9 

I wasn't sure if the ongoing refactoring prevents this from being merged and published as a patch, so sorry if it's not possible.

Anyway thanks for your project!