### PR TITLE
Update comparison with @js-temporal/polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Use a `<script>` tags with a CDN link:
   <tr>
     <td>Minified+gzip size</td>
     <td><a href='https://bundlephobia.com/package/temporal-polyfill'>20 KB<a></td>
-    <td><a href='https://bundlephobia.com/package/@js-temporal/polyfill'>56 KB</a> (+180%)</td>
+    <td><a href='https://bundlephobia.com/package/@js-temporal/polyfill'>52 KB</a> (+160%)</td>
   </tr>
   <tr>
     <td>Spec compliance</td>
@@ -99,7 +99,7 @@ Use a `<script>` tags with a CDN link:
       Apr 2024
     </td>
     <td>
-      May 2023
+      Mar 2025
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
`@js-temporal/polyfill` recently released [v0.5.0](https://github.com/js-temporal/temporal-polyfill/releases/tag/v0.5.0) which brings it in line with the latest Temporal spec.