### PR TITLE
Shrink the window size for time zone transition search

### DIFF
--- a/packages/temporal-polyfill/src/internal/timeZoneConfig.ts
+++ b/packages/temporal-polyfill/src/internal/timeZoneConfig.ts
@@ -3,7 +3,7 @@ import { secInDay } from './units'
 
 export const utcTimeZoneId = 'UTC'
 
-export const periodDur = secInDay * 60
+export const periodDur = secInDay * 6
 
 export const minPossibleTransition = isoArgsToEpochSec(1847)
 export const maxPossibleTransition = isoArgsToEpochSec(getCurrentYearPlus10())


### PR DESCRIPTION
This pull request will fix the bug of `startOfDay`, `getTimeZoneTransition` due to too wide window size. It will also fix offset calculation bug of `ZonedDateTime` partially.

This is a provisional fix until "a more robust algorithm" mentioned in <https://github.com/fullcalendar/temporal-polyfill/issues/73#issuecomment-3238123526> will be introduced.

```javascript
Temporal.ZonedDateTime.from("2000-10-08T03:00:00-03:00[America/Boa_Vista]").startOfDay();
// 2000-10-08T01:00:00-03:00[America/Boa_Vista], correct!
```

If we want to extend the window more, we have to hardcode "unusual" time zones and change the window size for each time zone ID, which isn't possible by design for now. (cf. https://github.com/tc39/proposal-temporal/pull/3112)

I'm not even sure hardcoding is reasonable from the perspective of bundle size, because extending the window only affect performance of `getTimeZoneTransition` (which itself is API for power users and therefore rarely used) when an offset transition doesn't exist few days after or before `ZonedDateTime`, which is (I guess) very uncommon case. For example, `startOfDay` uses `getTimeZoneTransition` internally, but it is guaranteed that an offset transition exists in 2 days in this case, so the window size is irrelevant.