### PR TITLE
fix(nextjs): initialize `new Date()` with `(0)` to avoid breaking Next.js 16 Cache Components pre-render

### DIFF
--- a/packages/temporal-polyfill/src/internal/timeMath.ts
+++ b/packages/temporal-polyfill/src/internal/timeMath.ts
@@ -328,7 +328,7 @@ export function isoToLegacyDate(
 
   // Note: Date.UTC() interprets one and two-digit years as being in the
   // 20th century, so don't use it
-  const legacyDate = new Date() // should throw out-of-range error here?
+  const legacyDate = new Date(0) // should throw out-of-range error here?
   legacyDate.setUTCHours(isoHour, isoMinute, isoSec, isoMilli)
   legacyDate.setUTCFullYear(isoYear, isoMonth - 1, isoDay + daysNudged)
 

--- a/packages/temporal-polyfill/src/internal/timeZoneConfig.ts
+++ b/packages/temporal-polyfill/src/internal/timeZoneConfig.ts
@@ -9,7 +9,7 @@ export const minPossibleTransition = isoArgsToEpochSec(1847)
 export const maxPossibleTransition = isoArgsToEpochSec(getCurrentYearPlus10())
 
 function getCurrentYearPlus10() {
-  const currentDate = /*@__PURE__*/ new Date()
+  const currentDate = /*@__PURE__*/ new Date(0)
   const currentYear = /*@__PURE__*/ currentDate.getUTCFullYear()
   return currentYear + 10
 }


### PR DESCRIPTION
Next.js Cache Components does not allow access to any "dynamic" data during pre-rendering, because this is intended to build a static shell that could be cached by a remote server. It throws an error to prevent mistakes - i.e. make the user make a conscious decision what they want to do with dynamic data (in your Next app, you would mark it as cached for some period of time, in which case it will be cached in the pre-render).

`new Date()` is one of those functions you need to mark as explicitly cached and tell Next.js how long to cache it for (because it's the current time, not a fixed date). `new Date('<some fixed>')` would not be flagged as it is not dynamic.

Unfortunately, `Temporal.Instant.from(<some fixed ISO string>)` is flagged as dynamic, because it is using `new Date()`... but then immediately setting it to a fixed value in `isoToLegacyDate`. This forces users to wrap it with caching, which is tedious and unnecessary when it is actually a fixed date:

```
Error: Route "/from-iso" used `new Date()` before accessing either uncached data (e.g. `fetch()`) or Request data (e.g. `cookies()`, `headers()`, `connection()`, and `searchParams`). Accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time
    at Home (page.tsx:4:35)
    at Home (<anonymous>:1:13)
```

This fix inits it with `new Date(0)` instead, which stops Next.js complaining about this.

*note: also raised this to Next.js: https://github.com/vercel/next.js/issues/88696 because it's a bit unergonomic that this pattern is flagged, although I can see why it'd be hard to detect.*

