### PR TITLE
Reject Duration strings with a dangling time designator

### DIFF
--- a/polyfill/src/funcApi/duration.test.ts
+++ b/polyfill/src/funcApi/duration.test.ts
@@ -67,6 +67,22 @@ describe('fromString', () => {
     const dur = DurationFns.fromString('P1D')
     expectDurationEquals(dur, { days: 1 })
   })
+
+  it('parses time components after the designator', () => {
+    expectDurationEquals(DurationFns.fromString('P1DT1H'), {
+      days: 1,
+      hours: 1,
+    })
+    expectDurationEquals(DurationFns.fromString('PT1H'), { hours: 1 })
+    expectDurationEquals(DurationFns.fromString('PT1M'), { minutes: 1 })
+    expectDurationEquals(DurationFns.fromString('PT1S'), { seconds: 1 })
+  })
+
+  it('rejects a time designator with no following time component', () => {
+    expect(() => DurationFns.fromString('P05DT')).toThrow(RangeError)
+    expect(() => DurationFns.fromString('P1DT')).toThrow(RangeError)
+    expect(() => DurationFns.fromString('PT')).toThrow(RangeError)
+  })
 })
 
 describe('fromFields', () => {

--- a/polyfill/src/internal/isoParse.ts
+++ b/polyfill/src/internal/isoParse.ts
@@ -546,7 +546,10 @@ const durationRegExp = createRegExp(
     '(\\d+M)?' + // 3:months
     '(\\d+W)?' + // 4:weeks
     '(\\d+D)?' + // 5:days
-    '(?:T' +
+    // Spec grammar (DurationTime) requires the time designator `T` to be
+    // followed by at least one H/M/S component. Each of those starts with a
+    // digit, so a `(?=\d)` lookahead rejects a dangling `T` (e.g. "P05DT").
+    '(?:T(?=\\d)' +
     `(?:(\\d+)${fractionRegExpStr}H)?` + // 6:hours, 7:partialHour
     `(?:(\\d+)${fractionRegExpStr}M)?` + // 8:minutes, 9:partialMinute
     `(?:(\\d+)${fractionRegExpStr}S)?` + // 10:seconds, 11:partialSecond


### PR DESCRIPTION
`Temporal.Duration.from('P05DT')` gives back a 5-day duration when it should throw. A `T` has to be followed by an actual time component (the `DurationTime` grammar), and the reference polyfill, js-temporal, and Firefox all reject it. Closes #65.

The time part of `durationRegExp` had H/M/S all optional after `T`, so a bare trailing `T` matched with nothing behind it. Added a `(?=\d)` lookahead after `T` so it needs at least one component. It's a lookahead, not a capture, so nothing downstream shifts.

Kept it to the regex. The other option is to capture the `T` and reject it in `organizeDurationParts` for a nicer error message, happy to go that way instead. Tests plus the full `Duration` test262 suite pass.

Saw your note on the issue about wanting to match this and send a test to tc39. It'd been sitting a while so I took a crack, but glad to step back if you'd rather take it.
