### PR TITLE
fix: restore module-sync export condition (#62)

### DIFF
--- a/polyfill/CHANGELOG.md
+++ b/polyfill/CHANGELOG.md
@@ -8,6 +8,14 @@ don't work in GH release markdown. must be absolute
 
 # `temporal-polyfill` Changelog
 
+## v1.0.3
+
+- FIX: Restore `module-sync` export condition, dropped in v1.0.0 (#62). CommonJS
+  consumers failed to even resolve the package (`ERR_PACKAGE_PATH_NOT_EXPORTED`).
+  All entrypoints now expose `module-sync` alongside `import`, both pointing at
+  the same ESM file, which Node v22.12+ and v20.19+ load synchronously from
+  `require()`.
+
 ## v1.0.2
 
 - TASK: Update to latest spec (2026-07-27) (#94, #3)

--- a/polyfill/scripts/manifest.js
+++ b/polyfill/scripts/manifest.js
@@ -39,6 +39,19 @@ async function writePkgJson(pkgDir, isDev) {
 
     distExportMap[exportPath] = {
       import: { types: typesPath, default: esmPath },
+      // `module-sync` matches for both `import` and `require()`, so it's less
+      // specific than `import` and goes after it, per Node's most-specific-first
+      // ordering rule. Order doesn't change what `require()` gets — `import` is
+      // mutually exclusive with `require`, so it can never win there — but it
+      // does keep `import` resolving through the entry that carries `types`.
+      // The point of the condition: without it, `require()` matches none of the
+      // keys and fails at resolution with ERR_PACKAGE_PATH_NOT_EXPORTED. Node
+      // v22.12+ / v20.19+ then loads this ESM file synchronously, which is only
+      // valid because the bundles have no top-level await (otherwise:
+      // ERR_REQUIRE_ASYNC_MODULE). Node versions predating require(esm), and
+      // bundlers, ignore the condition entirely — they're no worse off than
+      // before. Both keys point at one file, so there's no dual-package hazard.
+      'module-sync': esmPath,
     }
 
     if (!rootEsmPath) {


### PR DESCRIPTION
Fixes the CommonJS resolution regression introduced in v1, and restores the `module-sync` condition originally added for #62.

## Problem

v1 generates an `exports` map where every subpath has only an `"import"` condition:

```jsonc
".": {
  "import": { "types": "./index.d.ts", "default": "./index.js" }
}
```

Any CommonJS consumer fails at **resolution** time:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
.../node_modules/temporal-polyfill/package.json
  at exportsNotFound (node:internal/modules/esm/resolve:314:10)
  at resolveExports (node:internal/modules/cjs/loader:664:36)
```

This is *not* the intentional "Dropped CJS; ESM and global IIFE only" decision biting. Node v22.12+ and v20.19+ have `require(esm)` and load the shipped ESM synchronously without issue — it just never gets there. `require` resolution matches the conditions `["node", "require", "module-sync"]`, never `"import"` (which is always mutually exclusive with `"require"`), so it fails one stage earlier.

## Regression, not a feature request

#62 asked for exactly this, and it shipped in 0.3.2:

```jsonc
".": {
  "import": "./index.js",
  "require": "./index.cjs",
  "module-sync": "./index.js"
}
```

The v1 exports rewrite dropped both `require` and `module-sync`. `require` going away is intentional; `module-sync` going away looks like collateral.

## Fix

`polyfill/scripts/manifest.js` generates the map. Adds `module-sync` after `import` — it matches for both `import` and `require()`, making it the less specific of the two, and Node's documented rule is most-specific-first. Applies to all entrypoints including the iife ones (`./global` → `global.esm.js`):

```jsonc
".": {
  "import": { "types": "./index.d.ts", "default": "./index.js" },
  "module-sync": "./index.js"
}
```

Key order here doesn't change what `require()` resolves to — `import` can never match a `require()`, so `module-sync` wins regardless — but it does keep `import` resolving through the entry that carries `types`.

## Why this is safe

- Points at the same ESM file. No CJS build is resurrected.
- No top-level await in the bundles, so `require(esm)` works. (TLA would throw `ERR_REQUIRE_ASYNC_MODULE` instead.)
- `module-sync` is silently ignored by bundlers and by Node versions predating `require(esm)`, which are left exactly where they already are.
- `import` and `require` now resolve to one instance, which also closes the dual-package `instanceof` hazard from #62.

## Verification

All 20 generated entrypoints, `require()` and `import`, on Node v24.16.0:

```
20/20 require OK   (temporal-polyfill, /global, /shim, /implementation,
                    /full, /full/global, /full/shim, /full/implementation,
                    /types/global, /fns, /fns/{Calendar,Instant,ZonedDateTime,
                    PlainDateTime,PlainDate,PlainTime,PlainYearMonth,
                    PlainMonthDay,Duration,Now})
20/20 import OK
20/20 identical export keys AND identical bindings between the two
      (esm[k] === cjs[k] for every export -> one instance, no dual-package hazard)
```

Across Node versions (`require('temporal-polyfill')` / `import('temporal-polyfill')`):

| Node | `require()` | `import` |
| --- | --- | --- |
| v20.18.3 | `ERR_PACKAGE_PATH_NOT_EXPORTED` (predates `require(esm)`) | OK |
| v20.20.2 | OK | OK |
| v22.22.3 | OK | OK |
| v22.23.1 | OK | OK |
| v23.11.0 | OK | OK |
| v24.16.0 | OK | OK |

So the fix covers Node v20.19+ and v22.12+ — i.e. every version that has `require(esm)`. Below that, `module-sync` isn't a recognized condition and resolution still fails, exactly as it does today; no version is made worse.

Bundlers are unaffected: `examples/fns-and-global` rebuilds to a byte-identical chunk (`index-Dk8TfNin.js`, 95.72 kB) before and after.

`pnpm run lint` and `pnpm run tsc:all` pass; full workspace `pnpm run build` succeeds.

Separately verified against the published `temporal-polyfill@1.0.1` on Node v22.23.1 by patching only `"module-sync": "./index.js"` into the installed `package.json`: `require('temporal-polyfill')` starts working, and a Strapi 5 app (which compiles its server TS to CJS) goes from boot failure to "Strapi started successfully". Reverting the patch reproduces the failure.

## Two things this does *not* fix

Both are pre-existing on v1.0.2 and unchanged by this PR — flagging them in case they're worth separate issues:

1. **TypeScript types for CJS-mode consumers.** A `.cts` / CJS-mode file still gets `TS2307: Cannot find module 'temporal-polyfill'`, because TypeScript does not implement the `module-sync` condition — verified identical on TS 5.3.3 and TS 5.9.3, under both `node16` and `nodenext`. Byte-for-byte the same error against a v1.0.2-shaped `exports` map with `module-sync` stripped. `.mts` / ESM-mode types resolve fine. Fixing this would need a `require` condition carrying `types`, which conflicts with the deliberate CJS drop, so I left it alone.
2. **`./package.json` is not an exported subpath**, so `require('temporal-polyfill/package.json')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. Some tooling reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
