### PR TITLE
Fix `temporal-utils` compatibility with  CJS

### DIFF
--- a/utils/package.json
+++ b/utils/package.json
@@ -24,15 +24,15 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./protected": {
       "types": "./dist/protected.d.ts",
-      "import": "./dist/protected.js"
+      "default": "./dist/protected.js"
     },
     "./protected-error-messages": {
       "types": "./dist/protected-error-messages.d.ts",
-      "import": "./dist/protected-error-messages.js"
+      "default": "./dist/protected-error-messages.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
Fixes #100. 

Updates `temporal-utils`'s `package.json#exports` format to match that of `temporal-polyfill` to restore the ability to require the package from CJS.