### PR TITLE
Fix /full entrypoint not deferring to native Temporal

### DIFF
--- a/polyfill/src/classApi/basic/index.test.ts
+++ b/polyfill/src/classApi/basic/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { NativeTemporal } from '../../nativeSwitch'
+import { Temporal as TemporalBasicImpl } from './implementation'
+import { Intl as IntlBasic, Temporal as TemporalBasic } from './index'
+
+// basic/index.ts already selects. Its /full twin did not, and the omission survived
+// because neither entry had a test asserting the selection. Cover both, so the two
+// families stay symmetric.
+const hasNativeTemporal = Boolean(NativeTemporal)
+
+describe('basic entrypoint native precedence', () => {
+  it.runIf(hasNativeTemporal)('defers to native Temporal', () => {
+    expect(TemporalBasic).toBe(NativeTemporal)
+  })
+
+  it.runIf(hasNativeTemporal)('uses the host Intl alongside it', () => {
+    expect(IntlBasic).toBe(globalThis.Intl)
+  })
+
+  it.runIf(hasNativeTemporal)(
+    'leaves /implementation forced non-native',
+    () => {
+      expect(TemporalBasicImpl).not.toBe(NativeTemporal)
+    },
+  )
+
+  it.runIf(!hasNativeTemporal)(
+    'falls back to the bundled implementation',
+    () => {
+      expect(TemporalBasic).toBe(TemporalBasicImpl)
+    },
+  )
+})

--- a/polyfill/src/classApi/full/index.test.ts
+++ b/polyfill/src/classApi/full/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { NativeTemporal } from '../../nativeSwitch'
+import { Temporal as TemporalFullImpl } from './implementation'
+import { Intl as IntlFull, Temporal as TemporalFull } from './index'
+
+// The README documents /full as "uses native if available" and /full/implementation
+// as "forced non-native". Nothing asserted either claim, so the two entries were able
+// to collapse into the same object without a lane going red.
+const hasNativeTemporal = Boolean(NativeTemporal)
+
+describe('full entrypoint native precedence', () => {
+  it.runIf(hasNativeTemporal)('defers to native Temporal', () => {
+    expect(TemporalFull).toBe(NativeTemporal)
+  })
+
+  it.runIf(hasNativeTemporal)('uses the host Intl alongside it', () => {
+    expect(IntlFull).toBe(globalThis.Intl)
+  })
+
+  it.runIf(hasNativeTemporal)(
+    'leaves /full/implementation forced non-native',
+    () => {
+      expect(TemporalFullImpl).not.toBe(NativeTemporal)
+    },
+  )
+
+  it.runIf(!hasNativeTemporal)(
+    'falls back to the bundled implementation',
+    () => {
+      expect(TemporalFull).toBe(TemporalFullImpl)
+    },
+  )
+
+  // Whichever side won the selection, the expanded calendar set is why /full exists.
+  it('builds an expanded calendar either way', () => {
+    const date = TemporalFull.PlainDate.from('2026-08-09')
+    expect(date.withCalendar('hebrew').calendarId).toBe('hebrew')
+  })
+})

--- a/polyfill/src/classApi/full/index.ts
+++ b/polyfill/src/classApi/full/index.ts
@@ -1,1 +1,14 @@
-export * from './implementation'
+import { NativeTemporal } from '../../nativeSwitch'
+import * as Impl from './implementation'
+
+// Mirrors basic/index.ts. The expanded calendar set is a reason to ship a bigger
+// implementation, not a reason to shadow a host that already has Temporal --
+// full/shim.ts already defers, so /full/global does too.
+export const Temporal = NativeTemporal || Impl.Temporal
+
+const IntlExport = NativeTemporal ? Intl : Impl.Intl
+export { IntlExport as Intl }
+
+export const toTemporalInstant = NativeTemporal
+  ? (Date.prototype as any).toTemporalInstant
+  : Impl.toTemporalInstant


### PR DESCRIPTION
`temporal-polyfill/full` doesn't use native `Temporal` when it's available, but the README says it does, and `/full/global` does.  I think it's a small omission rather than a policy, but only you can say for sure, so I'd rather lay out what I found than open a fix and assume.

The base entrypoint selects:

```ts
// src/classApi/basic/index.ts
export const Temporal = NativeTemporal || Impl.Temporal
```

The full one doesn't:

```ts
// src/classApi/full/index.ts
export * from './implementation'
```

The part that convinced me it isn't deliberate is `src/classApi/full/shim.ts`, which does check:

```ts
export function install() {
  if (!NativeTemporal) {
    installImplementation()
  }
}
```

So `/full/global` defers to native and `/full` never does.  If withholding native from the calendar build were the intent, I'd expect `full/shim.ts` to install unconditionally.

There's a second piece of evidence pointing the same way.  `basic/` and `full/` carry the same 20 filenames, and I diffed every pair.  Ten are byte-identical, including all the plumbing, so `global.ts`, `shim.ts`, and `implementation.ts` are literally the same bytes in both families.  Nine of the ten that differ are the calendar bearing classes, `plainDate.ts`, `zonedDateTime.ts`, `calendarResolve.ts`, and so on, which is the whole point of the split.  The tenth is `index.ts`.

The other half of it is that `/full` and `/full/implementation` are documented as different entrypoints, README lines 93 and 101, "uses native if available" against "forced non-native", but they build to the same bytes:

```
full/index.js           export { IntlExtended as Intl, Temporal, toTemporalInstant } from "../chunks/classApi-full.js";
full/implementation.js  export { IntlExtended as Intl, Temporal, toTemporalInstant } from "../chunks/classApi-full.js";
```

Measured on Node 26.2.0, which is the native lane in the matrix, `temporal-polyfill` is `=== globalThis.Temporal` and `temporal-polyfill/full` is not, and `full` and `full/implementation` come back as the same object.

I ran into this from the outside.  I maintain [daymath](https://github.com/leemr/daymath), a small calendar date library, and it needed the expanded calendars, so it moved from `temporal-polyfill` to `temporal-polyfill/full`.  That quietly stopped it using native Temporal on Node 26 and Deno.  Nothing failed, since native and the bundled build agree on everything daymath touches, so it took a while to notice.

It now carries [its own selection](https://github.com/leemr/daymath/blob/fe6371c/index.js#L92) in shipped code, under a long comment explaining why that line can't be removed, plus [a cross-runtime check](https://github.com/leemr/daymath/blob/fe6371c/scripts/cross-runtime.mjs#L94-L126) that asserts on every lane which implementation actually ran.  That second one exists because a "native Temporal" banner read off `globalThis` says what the runtime has, not what the library picked, so the two implementations get told apart by how they word the same out of range error.  The workaround is really the thing I'd like to delete.

I did check the counter-argument before writing any of this.  Issue #71 raised native deferral and flagged that `tc39/proposal-intl-era-monthcode` is still in progress, and #19 has the W3C guidance about not deferring to native before a feature reaches a tipping point.  That's a fair reason to hold native back from the calendar build.  I just can't square it with `full/shim.ts` deferring.  If the code is what you meant, I'm happy to close this and send a README change instead, saying that `/full` never defers and why.

The fix makes `full/index.ts` mirror `basic/index.ts`.

On tests, there was nothing asserting the selection on either entrypoint, only on `implementation`, which I think is how this stayed quiet.  I added an `index.test.ts` beside each one, using the `it.runIf(hasNativeTemporal)` shape from `funcApi/toTemporal.test.ts`.  I added the basic one as well, since without it that half stays in exactly the unguarded state that let this through.  As a control, reverting `full/index.ts` to the one liner fails 2 tests in the new full file, on `Temporal` and on `Intl`, and leaves the basic file green.

Everything below was run from `polyfill`, on the Node versions in the ci.yml matrix.  `pnpm run lint` and `pnpm run tsc:all` pass.  `pnpm run vitest` passes on 18.19.0, 20.10.0, 22.14.0, 24.16.0, and 26.2.0, and the new native gated cases run for real on 26.2.0, which is the only lane that has native Temporal.  `pnpm run test262 --no-max` passes on 26.2.0 with 5546 passed and 0 failed, and on 22.14.0 with 6840 passed and 0 failed.  Neither lane has anything passing unexpectedly.

test262 is unaffected by this change, and I checked that rather than assuming it.  The runner loads `dist/full/global.js` or `dist/global.js`, and both hash identically with and without the fix.  Only `dist/full/index.js` changes.

One unrelated note in case you hit it: my first install failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`, because pnpm 11 no longer reads `pnpm.overrides` out of `package.json`.  The 10.20.0 pinned in ci.yml works fine.  Nothing to do with this PR, and I'm happy to open a separate issue for it.

If this lands, a changelog line could be:

```
- Fixed: `temporal-polyfill/full` now uses native `Temporal` when available,
  matching the base entrypoint and the documented behavior.
```
